### PR TITLE
Strip trailing n from knight promotion moves.

### DIFF
--- a/src/lcztools/backend/_leela_net.py
+++ b/src/lcztools/backend/_leela_net.py
@@ -44,7 +44,8 @@ class LeelaNet:
             policy = policy.numpy()
             value = value.numpy()
         policy, value = policy[0], value[0][0]
-        legal_uci = [m.uci() for m in leela_board.generate_legal_moves()]
+        # Knight promotions are represented without a suffix in leela-chess
+        legal_uci = [m.uci().rstrip('n') for m in leela_board.generate_legal_moves()]
         if legal_uci:
             legal_indexes = leela_board.lcz_uci_to_idx(legal_uci)
             softmaxed = _softmax(policy[legal_indexes])


### PR DESCRIPTION
lczero-chess represents knight promotions without a suffix character.
Without this change, evaluation fails when knight promotion is
a possible move.